### PR TITLE
1.0.2; Added latest devel commits + update error message

### DIFF
--- a/common/os_calls.c
+++ b/common/os_calls.c
@@ -2387,6 +2387,34 @@ g_htoi(char *str)
 }
 
 /*****************************************************************************/
+/* returns number of bytes copied into out_str */
+int APP_CC
+g_bytes_to_hexstr(const void *bytes, int num_bytes, char *out_str,
+                  int bytes_out_str)
+{
+    int rv;
+    int index;
+    char *lout_str;
+    const tui8 *lbytes;
+
+    rv = 0;
+    lbytes = (const tui8 *) bytes;
+    lout_str = out_str;
+    for (index = 0; index < num_bytes; index++)
+    {
+        if (bytes_out_str < 3)
+        {
+            break;
+        }
+        g_snprintf(lout_str, bytes_out_str, "%2.2x", lbytes[index]);
+        lout_str += 2;
+        bytes_out_str -= 2;
+        rv += 2;
+    }
+    return rv;
+}
+
+/*****************************************************************************/
 int APP_CC
 g_pos(const char *str, const char *to_find)
 {

--- a/common/os_calls.h
+++ b/common/os_calls.h
@@ -140,6 +140,7 @@ int APP_CC      g_strcasecmp(const char* c1, const char* c2);
 int APP_CC      g_strncasecmp(const char* c1, const char* c2, int len);
 int APP_CC      g_atoi(const char* str);
 int APP_CC      g_htoi(char* str);
+int APP_CC      g_bytes_to_hexstr(const void *bytes, int num_bytes, char *out_str, int bytes_out_str);
 int APP_CC      g_pos(const char* str, const char* to_find);
 int APP_CC      g_mbstowcs(twchar* dest, const char* src, int n);
 int APP_CC      g_wcstombs(char* dest, const twchar* src, int n);

--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -100,7 +100,7 @@ struct xrdp_client_info
   char orders[32];
   int order_flags_ex;
   int use_bulk_comp;
-  int pointer_flags; /* 0 color, 1 new, 2 no new */
+  int pointer_flags; /* 0 color, 1 new, 2 no new or large, 4 large */
   int use_fast_path;
   int require_credentials; /* when true, credentials *must* be passed on cmd line */
   char client_addr[256];

--- a/libxrdp/libxrdpinc.h
+++ b/libxrdp/libxrdpinc.h
@@ -107,6 +107,8 @@ libxrdp_send_pointer_ex(struct xrdp_session *session, int cache_idx,
 int DEFAULT_CC
 libxrdp_set_pointer(struct xrdp_session *session, int cache_idx);
 int DEFAULT_CC
+libxrdp_set_pointer_system(struct xrdp_session *session, int sys_type);
+int DEFAULT_CC
 libxrdp_orders_init(struct xrdp_session *session);
 int DEFAULT_CC
 libxrdp_orders_send(struct xrdp_session *session);

--- a/libxrdp/libxrdpinc.h
+++ b/libxrdp/libxrdpinc.h
@@ -101,6 +101,10 @@ int DEFAULT_CC
 libxrdp_send_pointer(struct xrdp_session *session, int cache_idx,
                      char *data, char *mask, int x, int y, int bpp);
 int DEFAULT_CC
+libxrdp_send_pointer_ex(struct xrdp_session *session, int cache_idx,
+                        char *data, char *mask, int x, int y, int bpp,
+                        int width, int height);
+int DEFAULT_CC
 libxrdp_set_pointer(struct xrdp_session *session, int cache_idx);
 int DEFAULT_CC
 libxrdp_orders_init(struct xrdp_session *session);

--- a/libxrdp/xrdp_caps.c
+++ b/libxrdp/xrdp_caps.c
@@ -540,10 +540,14 @@ xrdp_caps_process_largepointer(struct xrdp_rdp *self, struct stream *s,
     if (largePointerSupportFlags == 1) /* LARGE_POINTER_FLAG_96x96 */
     {
         self->client_info.pointer_flags |= 4;
+        g_writeln("xrdp_caps_process_pointer: client does support "
+                  "large cursors");
     }
     else
     {
         self->client_info.pointer_flags &= ~4;
+        g_writeln("xrdp_caps_process_pointer: client does not support "
+                  "large cursors");
     }
     return 0;
 }

--- a/libxrdp/xrdp_orders_rail.c
+++ b/libxrdp/xrdp_orders_rail.c
@@ -581,6 +581,12 @@ xrdp_orders_send_notify_new_update(struct xrdp_orders *self,
         order_size += 3;
     }
 
+    if (order_size < 16)
+    {
+        /* no flags set */
+        return 0;
+    }
+
     if (xrdp_orders_check(self, order_size) != 0)
     {
         return 1;
@@ -673,6 +679,12 @@ xrdp_orders_send_monitored_desktop(struct xrdp_orders *self,
         order_size += 1;
         /* WindowIds (variable) */
         order_size += mdo->num_window_ids *  4;
+    }
+
+    if (order_size < 8)
+    {
+        /* no flags set */
+        return 0;
     }
 
     if (xrdp_orders_check(self, order_size) != 0)

--- a/libxrdp/xrdp_orders_rail.c
+++ b/libxrdp/xrdp_orders_rail.c
@@ -191,15 +191,18 @@ xrdp_orders_send_as_unicode(struct stream *s, const char *text)
     int str_chars;
     int index;
     int i32;
-    twchar wdst[256];
+    twchar *wdst;
 
-    str_chars = g_mbstowcs(wdst, text, 255);
-
+    wdst = (twchar *) g_malloc(sizeof(twchar) * 64 * 1024, 1);
+    if (wdst == 0)
+    {
+        return 1;
+    }
+    str_chars = g_mbstowcs(wdst, text, 2 * 1024);
     if (str_chars > 0)
     {
         i32 = str_chars * 2;
         out_uint16_le(s, i32);
-
         for (index = 0; index < str_chars; index++)
         {
             i32 = wdst[index];
@@ -210,7 +213,7 @@ xrdp_orders_send_as_unicode(struct stream *s, const char *text)
     {
         out_uint16_le(s, 0);
     }
-
+    g_free(wdst);
     return 0;
 }
 
@@ -256,6 +259,7 @@ xrdp_orders_send_window_new_update(struct xrdp_orders *self, int window_id,
     {
         /* titleInfo */
         num_chars = g_mbstowcs(0, window_state->title_info, 0);
+        num_chars = MIN(num_chars, 2 * 1024);
         order_size += 2 * num_chars + 2;
     }
 
@@ -532,6 +536,7 @@ xrdp_orders_send_notify_new_update(struct xrdp_orders *self,
     {
         /* ToolTip (variable) UNICODE_STRING */
         num_chars = g_mbstowcs(0, notify_state->tool_tip, 0);
+        num_chars = MIN(num_chars, 2 * 1024);
         order_size += 2 * num_chars + 2;
     }
 
@@ -540,9 +545,11 @@ xrdp_orders_send_notify_new_update(struct xrdp_orders *self,
         /* InfoTip (variable) TS_NOTIFY_ICON_INFOTIP */
         /* UNICODE_STRING */
         num_chars = g_mbstowcs(0, notify_state->infotip.title, 0);
+        num_chars = MIN(num_chars, 2 * 1024);
         order_size += 2 * num_chars + 2;
         /* UNICODE_STRING */
         num_chars = g_mbstowcs(0, notify_state->infotip.text, 0);
+        num_chars = MIN(num_chars, 2 * 1024);
         order_size += 2 * num_chars + 2;
         /* Timeout (4 bytes) */
         /* InfoFlags (4 bytes) */

--- a/libxrdp/xrdp_orders_rail.c
+++ b/libxrdp/xrdp_orders_rail.c
@@ -260,6 +260,7 @@ xrdp_orders_send_window_new_update(struct xrdp_orders *self, int window_id,
         /* titleInfo */
         num_chars = g_mbstowcs(0, window_state->title_info, 0);
         num_chars = MIN(num_chars, 2 * 1024);
+        num_chars = MAX(num_chars, 0);
         order_size += 2 * num_chars + 2;
     }
 
@@ -537,6 +538,7 @@ xrdp_orders_send_notify_new_update(struct xrdp_orders *self,
         /* ToolTip (variable) UNICODE_STRING */
         num_chars = g_mbstowcs(0, notify_state->tool_tip, 0);
         num_chars = MIN(num_chars, 2 * 1024);
+        num_chars = MAX(num_chars, 0);
         order_size += 2 * num_chars + 2;
     }
 
@@ -546,10 +548,12 @@ xrdp_orders_send_notify_new_update(struct xrdp_orders *self,
         /* UNICODE_STRING */
         num_chars = g_mbstowcs(0, notify_state->infotip.title, 0);
         num_chars = MIN(num_chars, 2 * 1024);
+        num_chars = MAX(num_chars, 0);
         order_size += 2 * num_chars + 2;
         /* UNICODE_STRING */
         num_chars = g_mbstowcs(0, notify_state->infotip.text, 0);
         num_chars = MIN(num_chars, 2 * 1024);
+        num_chars = MAX(num_chars, 0);
         order_size += 2 * num_chars + 2;
         /* Timeout (4 bytes) */
         /* InfoFlags (4 bytes) */

--- a/libxrdp/xrdp_orders_rail.c
+++ b/libxrdp/xrdp_orders_rail.c
@@ -338,12 +338,6 @@ xrdp_orders_send_window_new_update(struct xrdp_orders *self, int window_id,
         order_size += 8 * window_state->num_visibility_rects;
     }
 
-    if (order_size < 12)
-    {
-        /* no flags set */
-        return 0;
-    }
-
     if (xrdp_orders_check(self, order_size) != 0)
     {
         return 1;
@@ -592,12 +586,6 @@ xrdp_orders_send_notify_new_update(struct xrdp_orders *self,
         order_size += 3;
     }
 
-    if (order_size < 16)
-    {
-        /* no flags set */
-        return 0;
-    }
-
     if (xrdp_orders_check(self, order_size) != 0)
     {
         return 1;
@@ -690,12 +678,6 @@ xrdp_orders_send_monitored_desktop(struct xrdp_orders *self,
         order_size += 1;
         /* WindowIds (variable) */
         order_size += mdo->num_window_ids *  4;
-    }
-
-    if (order_size < 8)
-    {
-        /* no flags set */
-        return 0;
     }
 
     if (xrdp_orders_check(self, order_size) != 0)

--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -1113,7 +1113,10 @@ static void DEFAULT_CC
 lfreerdp_pointer_system(rdpContext *context,
                         POINTER_SYSTEM_UPDATE *pointer_system)
 {
-    LLOGLN(0, ("lfreerdp_pointer_system: - no code here type value = %d",pointer_system->type));
+    struct mod *mod;
+
+    mod = ((struct mod_context *)context)->modi;
+    mod->server_set_pointer_system(mod, pointer_system->type);
 }
 
 /******************************************************************************/

--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -21,6 +21,7 @@
 #include "xrdp-color.h"
 #include "xrdp_rail.h"
 #include "log.h"
+#include "ssl_calls.h"
 #include <freerdp/settings.h>
 #include <X11/Xlib.h>
 
@@ -169,10 +170,23 @@ lxrdp_connect(struct mod *mod)
     }
     else
     {
+        char password_sha1[20];
+        char password_sha1_text[256];
+        void *sha1;
+
         log_message(LOG_LEVEL_INFO, "freerdp_connect returned Success to "
                     "destination :%s:%d",
                     mod->inst->settings->hostname,
                     mod->inst->settings->port);
+        sha1 = ssl_sha1_info_create();
+        ssl_sha1_transform(sha1, mod->inst->settings->password, strlen(mod->inst->settings->password));
+        ssl_sha1_complete(sha1, password_sha1);
+        g_bytes_to_hexstr(password_sha1, 20, password_sha1_text, 256);
+        log_message(LOG_LEVEL_INFO, "  username %s password length %d password sha1 %s",
+                    mod->inst->settings->username,
+                    strlen(mod->inst->settings->password),
+                    password_sha1_text);
+        ssl_sha1_info_delete(sha1);
     }
 
     return 0;

--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -186,6 +186,11 @@ lxrdp_connect(struct mod *mod)
                     mod->inst->settings->username,
                     strlen(mod->inst->settings->password),
                     password_sha1_text);
+        log_message(LOG_LEVEL_INFO, "  domain %s hostname %s port %d nla_security %d",
+                    mod->inst->settings->domain,
+                    mod->inst->settings->hostname,
+                    mod->inst->settings->port,
+                    mod->inst->settings->nla_security);
         ssl_sha1_info_delete(sha1);
     }
 

--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -102,14 +102,14 @@ lxrdp_connect(struct mod *mod)
         char *err_name = g_strdup(freerdp_get_last_error_name(err_code));
         char *err_string = g_strdup(freerdp_get_last_error_string(err_code));
         log_message(LOG_LEVEL_ERROR,
-                    "NeutrinoRDP failed to connect to host: %s:%d\n"
+                    "Osirium: failed to connect to host: %s:%d\n"
                     "Error Name: %s\n"
                     "Error Description: %s",
                     mod->inst->settings->hostname,
                     mod->inst->settings->port,
                     err_name,
                     err_string);
-        mod->server_msg(mod, "NeutrinoRDP connection failed.", 0);
+        mod->server_msg(mod, "Osirium: connection failed.", 0);
         mod->server_msg(mod, "Hostname:", 0);
         mod->server_msg(mod, mod->inst->settings->hostname, 0);
         mod->server_msg(mod, "Error:", 0);

--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -1115,6 +1115,7 @@ lfreerdp_pointer_system(rdpContext *context,
 {
     struct mod *mod;
 
+    LLOGLN(10, ("lfreerdp_pointer_system:"));
     mod = ((struct mod_context *)context)->modi;
     mod->server_set_pointer_system(mod, pointer_system->type);
 }
@@ -1144,6 +1145,22 @@ lfreerdp_get_pixel(void *bits, int width, int height, int bpp,
         shift = x % 8;
         pixel = (src8[start] & (0x80 >> shift)) != 0;
         return pixel ? 0xffffff : 0;
+    }
+    else if ((bpp == 15) || (bpp == 16))
+    {
+        src8 = (tui8 *)bits;
+        src8 += y * delta + x * 2;
+        pixel = ((short*)(src8))[0];
+        return pixel;
+    }
+    else if (bpp == 24)
+    {
+        src8 = (tui8 *)bits;
+        src8 += y * delta + x * 3;
+        pixel = src8[0];
+        pixel |= src8[1] << 8;
+        pixel |= src8[2] << 16;
+        return pixel;
     }
     else if (bpp == 32)
     {
@@ -1183,6 +1200,12 @@ lfreerdp_set_pixel(int pixel, void *bits, int width, int height, int bpp,
         {
             dst8[start] = dst8[start] & ~(0x80 >> shift);
         }
+    }
+    else if ((bpp == 15) || (bpp == 16))
+    {
+        dst8 = (tui8 *)bits;
+        dst8 += y * delta + x * 2;
+        ((short*)(dst8))[0] = pixel;
     }
     else if (bpp == 24)
     {

--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -1521,11 +1521,12 @@ lfreerdp_pre_connect(freerdp *instance)
         instance->settings->remote_app = 1;
         instance->settings->rail_langbar_supported = 1;
         instance->settings->workarea = 1;
-        instance->settings->performance_flags = PERF_DISABLE_WALLPAPER | PERF_DISABLE_FULLWINDOWDRAG;
+        instance->settings->performance_flags = mod->client_info.rdp5_performanceflags;
         instance->settings->num_icon_caches = mod->client_info.wnd_num_icon_caches;
         instance->settings->num_icon_cache_entries = mod->client_info.wnd_num_icon_cache_entries;
-
-
+        instance->settings->kbd_layout = mod->client_info.keylayout;
+        instance->settings->kbd_type = mod->client_info.keyboard_type;
+        instance->settings->kbd_subtype = mod->client_info.keyboard_subtype;
     }
     else
     {

--- a/neutrinordp/xrdp-neutrinordp.h
+++ b/neutrinordp/xrdp-neutrinordp.h
@@ -178,7 +178,8 @@ struct mod
                              int data_bytes);
   int (*server_set_pointer_large)(struct mod* v, int x, int y, char* data,
                                   char* mask, int bpp, int width, int height);
-  tintptr server_dumby[100 - 45]; /* align, 100 minus the number of server
+  int (*server_set_pointer_system)(struct mod* v, int sys_type);
+  tintptr server_dumby[100 - 46]; /* align, 100 minus the number of server
                                      functions above */
   /* common */
   tintptr handle; /* pointer to self as long */

--- a/neutrinordp/xrdp-neutrinordp.h
+++ b/neutrinordp/xrdp-neutrinordp.h
@@ -51,11 +51,14 @@ struct brush_item
 
 struct pointer_item
 {
+  int pad0;
   int hotx;
   int hoty;
-  char data[32 * 32 * 4];
-  char mask[32 * 32 / 8];
   int bpp;
+  int width;
+  int height;
+  char data[96 * 96 * 4];
+  char mask[96 * 96 / 8];
 };
 
 #define CURRENT_MOD_VER 3
@@ -173,7 +176,9 @@ struct mod
                             int flags, int frame_id);
   int (*server_session_info)(struct mod* v, const char *data,
                              int data_bytes);
-  tintptr server_dumby[100 - 44]; /* align, 100 minus the number of server
+  int (*server_set_pointer_large)(struct mod* v, int x, int y, char* data,
+                                  char* mask, int bpp, int width, int height);
+  tintptr server_dumby[100 - 45]; /* align, 100 minus the number of server
                                      functions above */
   /* common */
   tintptr handle; /* pointer to self as long */

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -520,4 +520,6 @@ server_session_info(struct xrdp_mod *mod, const char *data, int data_bytes);
 int DEFAULT_CC
 server_set_pointer_large(struct xrdp_mod* mod, int x, int y, char* data,
                          char* mask, int bpp, int width, int height);
+int DEFAULT_CC
+server_set_pointer_system(struct xrdp_mod* mod, int sys_type);
 

--- a/xrdp/xrdp.h
+++ b/xrdp/xrdp.h
@@ -129,10 +129,11 @@ int APP_CC
 xrdp_wm_pu(struct xrdp_wm* self, struct xrdp_bitmap* control);
 int APP_CC
 xrdp_wm_send_pointer(struct xrdp_wm* self, int cache_idx,
-                     char* data, char* mask, int x, int y, int bpp);
+                     char* data, char* mask, int x, int y, int bpp,
+                     int width, int height);
 int APP_CC
 xrdp_wm_pointer(struct xrdp_wm* self, char* data, char* mask, int x, int y,
-                int bpp);
+                int bpp, int width, int height);
 int
 callback(long id, int msg, long param1, long param2, long param3, long param4);
 int APP_CC
@@ -516,4 +517,7 @@ server_add_char_alpha(struct xrdp_mod* mod, int font, int character,
                       int width, int height, char* data);
 int DEFAULT_CC
 server_session_info(struct xrdp_mod *mod, const char *data, int data_bytes);
+int DEFAULT_CC
+server_set_pointer_large(struct xrdp_mod* mod, int x, int y, char* data,
+                         char* mask, int bpp, int width, int height);
 

--- a/xrdp/xrdp_cache.c
+++ b/xrdp/xrdp_cache.c
@@ -638,10 +638,12 @@ xrdp_cache_add_pointer(struct xrdp_cache *self,
         if (self->pointer_items[i].x == pointer_item->x &&
                 self->pointer_items[i].y == pointer_item->y &&
                 g_memcmp(self->pointer_items[i].data,
-                         pointer_item->data, 32 * 32 * 4) == 0 &&
+                         pointer_item->data, 96 * 96 * 4) == 0 &&
                 g_memcmp(self->pointer_items[i].mask,
-                         pointer_item->mask, 32 * 32 / 8) == 0 &&
-                self->pointer_items[i].bpp == pointer_item->bpp)
+                         pointer_item->mask, 96 * 96 / 8) == 0 &&
+                self->pointer_items[i].bpp == pointer_item->bpp &&
+                self->pointer_items[i].width == pointer_item->width &&
+                self->pointer_items[i].height == pointer_item->height)
         {
             self->pointer_items[i].stamp = self->pointer_stamp;
             xrdp_wm_set_pointer(self->wm, i);
@@ -667,17 +669,21 @@ xrdp_cache_add_pointer(struct xrdp_cache *self,
     self->pointer_items[index].x = pointer_item->x;
     self->pointer_items[index].y = pointer_item->y;
     g_memcpy(self->pointer_items[index].data,
-             pointer_item->data, 32 * 32 * 4);
+             pointer_item->data, 96 * 96 * 4);
     g_memcpy(self->pointer_items[index].mask,
-             pointer_item->mask, 32 * 32 / 8);
+             pointer_item->mask, 96 * 96 / 8);
     self->pointer_items[index].stamp = self->pointer_stamp;
     self->pointer_items[index].bpp = pointer_item->bpp;
+    self->pointer_items[index].width = pointer_item->width;
+    self->pointer_items[index].height = pointer_item->height;
     xrdp_wm_send_pointer(self->wm, index,
                          self->pointer_items[index].data,
                          self->pointer_items[index].mask,
                          self->pointer_items[index].x,
                          self->pointer_items[index].y,
-                         self->pointer_items[index].bpp);
+                         self->pointer_items[index].bpp,
+                         self->pointer_items[index].width,
+                         self->pointer_items[index].height);
     self->wm->current_pointer = index;
     DEBUG(("adding pointer at %d", index));
     return index;
@@ -699,17 +705,21 @@ xrdp_cache_add_pointer_static(struct xrdp_cache *self,
     self->pointer_items[index].x = pointer_item->x;
     self->pointer_items[index].y = pointer_item->y;
     g_memcpy(self->pointer_items[index].data,
-             pointer_item->data, 32 * 32 * 4);
+             pointer_item->data, 96 * 96 * 4);
     g_memcpy(self->pointer_items[index].mask,
-             pointer_item->mask, 32 * 32 / 8);
+             pointer_item->mask, 96 * 96 / 8);
     self->pointer_items[index].stamp = self->pointer_stamp;
     self->pointer_items[index].bpp = pointer_item->bpp;
+    self->pointer_items[index].width = pointer_item->width;
+    self->pointer_items[index].height = pointer_item->height;
     xrdp_wm_send_pointer(self->wm, index,
                          self->pointer_items[index].data,
                          self->pointer_items[index].mask,
                          self->pointer_items[index].x,
                          self->pointer_items[index].y,
-                         self->pointer_items[index].bpp);
+                         self->pointer_items[index].bpp,
+                         self->pointer_items[index].width,
+                         self->pointer_items[index].height);
     self->wm->current_pointer = index;
     DEBUG(("adding pointer at %d", index));
     return index;

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -467,6 +467,7 @@ xrdp_mm_setup_mod1(struct xrdp_mm *self)
             self->mod->server_composite = server_composite;
             self->mod->server_paint_rects = server_paint_rects;
             self->mod->server_session_info = server_session_info;
+            self->mod->server_set_pointer_large = server_set_pointer_large;
             self->mod->si = (tintptr) &(self->wm->session->si);
         }
     }
@@ -2623,14 +2624,24 @@ server_session_info(struct xrdp_mod *mod, const char *data, int data_bytes)
 
 /*****************************************************************************/
 int DEFAULT_CC
+server_set_pointer_large(struct xrdp_mod* mod, int x, int y, char* data,
+                         char* mask, int bpp, int width, int height)
+{
+    struct xrdp_wm *wm;
+
+    wm = (struct xrdp_wm *)(mod->wm);
+    return xrdp_wm_pointer(wm, data, mask, x, y, bpp, width, height);
+}
+
+/*****************************************************************************/
+int DEFAULT_CC
 server_set_pointer(struct xrdp_mod *mod, int x, int y,
                    char *data, char *mask)
 {
     struct xrdp_wm *wm;
 
     wm = (struct xrdp_wm *)(mod->wm);
-    xrdp_wm_pointer(wm, data, mask, x, y, 0);
-    return 0;
+    return xrdp_wm_pointer(wm, data, mask, x, y, 0, 32, 32);
 }
 
 /*****************************************************************************/
@@ -2641,8 +2652,7 @@ server_set_pointer_ex(struct xrdp_mod *mod, int x, int y,
     struct xrdp_wm *wm;
 
     wm = (struct xrdp_wm *)(mod->wm);
-    xrdp_wm_pointer(wm, data, mask, x, y, bpp);
-    return 0;
+    return xrdp_wm_pointer(wm, data, mask, x, y, bpp, 32, 32);
 }
 
 /*****************************************************************************/

--- a/xrdp/xrdp_mm.c
+++ b/xrdp/xrdp_mm.c
@@ -468,6 +468,7 @@ xrdp_mm_setup_mod1(struct xrdp_mm *self)
             self->mod->server_paint_rects = server_paint_rects;
             self->mod->server_session_info = server_session_info;
             self->mod->server_set_pointer_large = server_set_pointer_large;
+            self->mod->server_set_pointer_system = server_set_pointer_system;
             self->mod->si = (tintptr) &(self->wm->session->si);
         }
     }
@@ -2653,6 +2654,16 @@ server_set_pointer_ex(struct xrdp_mod *mod, int x, int y,
 
     wm = (struct xrdp_wm *)(mod->wm);
     return xrdp_wm_pointer(wm, data, mask, x, y, bpp, 32, 32);
+}
+
+/*****************************************************************************/
+int DEFAULT_CC
+server_set_pointer_system(struct xrdp_mod* mod, int sys_type)
+{
+    struct xrdp_wm *wm;
+
+    wm = (struct xrdp_wm *)(mod->wm);
+    return libxrdp_set_pointer_system(wm->session, sys_type);
 }
 
 /*****************************************************************************/

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -148,7 +148,9 @@ struct xrdp_mod
                             int flags, int frame_id);
   int (*server_session_info)(struct xrdp_mod* v, const char *data,
                              int data_bytes);
-  tintptr server_dumby[100 - 44]; /* align, 100 minus the number of server
+  int (*server_set_pointer_large)(struct xrdp_mod* v, int x, int y, char* data,
+                                  char* mask, int bpp, int width, int height);
+  tintptr server_dumby[100 - 45]; /* align, 100 minus the number of server
                                      functions above */
   /* common */
   tintptr handle; /* pointer to self as int */
@@ -209,9 +211,11 @@ struct xrdp_pointer_item
   int stamp;
   int x; /* hotspot */
   int y;
-  char data[32 * 32 * 4];
-  char mask[32 * 32 / 8];
   int bpp;
+  int width;
+  int height;
+  char data[96 * 96 * 4];
+  char mask[96 * 96 / 8];
 };
 
 struct xrdp_brush_item

--- a/xrdp/xrdp_types.h
+++ b/xrdp/xrdp_types.h
@@ -150,7 +150,8 @@ struct xrdp_mod
                              int data_bytes);
   int (*server_set_pointer_large)(struct xrdp_mod* v, int x, int y, char* data,
                                   char* mask, int bpp, int width, int height);
-  tintptr server_dumby[100 - 45]; /* align, 100 minus the number of server
+  int (*server_set_pointer_system)(struct xrdp_mod* v, int sys_type);
+  tintptr server_dumby[100 - 46]; /* align, 100 minus the number of server
                                      functions above */
   /* common */
   tintptr handle; /* pointer to self as int */


### PR DESCRIPTION
Error message (which is now displayed in the 'Grey box') has been tweaked to say 'Osirium' instead of NeutrinoRDP.

Due to some bads (caused by me, sorry) I had to rebase some of the later commits to clean up the repo.

Requires osirium/NeutrinoRDP#1