### PR TITLE
Fetch client timezone info

### DIFF
--- a/common/xrdp_client_info.h
+++ b/common/xrdp_client_info.h
@@ -30,6 +30,31 @@ struct monitor_info
   int is_primary;
 };
 
+/* TS_SYSTEM_TIME */
+struct system_time
+{
+  unsigned short year;
+  unsigned short month;
+  unsigned short day_of_week;
+  unsigned short day;
+  unsigned short hour;
+  unsigned short minute;
+  unsigned short second;
+  unsigned short milliseconds;
+};
+
+/* TS_TIME_ZONE_INFORMATION */
+struct timezone_info
+{
+  unsigned int        bias;
+  char                standard_name[32];
+  struct system_time  standard_date;
+  unsigned int        standard_bias;
+  char                daylight_name[32];
+  struct system_time  daylight_date;
+  unsigned int        daylight_bias;
+};
+
 struct xrdp_client_info
 {
   int size; /* bytes for this structure */
@@ -145,6 +170,7 @@ struct xrdp_client_info
   int use_osirium_preamble;
   char *osirium_preamble_buffer;
 
+  struct timezone_info timezone_info;
 };
 
 #endif

--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -186,6 +186,11 @@ lxrdp_connect(struct mod *mod)
                     mod->inst->settings->username,
                     strlen(mod->inst->settings->password),
                     password_sha1_text);
+        log_message(LOG_LEVEL_INFO, "  domain %s hostname %s port %d nla_security %d",
+                    mod->inst->settings->domain,
+                    mod->inst->settings->hostname,
+                    mod->inst->settings->port,
+                    mod->inst->settings->nla_security);
         ssl_sha1_info_delete(sha1);
     }
 

--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -1573,11 +1573,12 @@ lfreerdp_pre_connect(freerdp *instance)
         instance->settings->remote_app = 1;
         instance->settings->rail_langbar_supported = 1;
         instance->settings->workarea = 1;
-        instance->settings->performance_flags = PERF_DISABLE_WALLPAPER | PERF_DISABLE_FULLWINDOWDRAG;
+        instance->settings->performance_flags = mod->client_info.rdp5_performanceflags;
         instance->settings->num_icon_caches = mod->client_info.wnd_num_icon_caches;
         instance->settings->num_icon_cache_entries = mod->client_info.wnd_num_icon_cache_entries;
-
-
+        instance->settings->kbd_layout = mod->client_info.keylayout;
+        instance->settings->kbd_type = mod->client_info.keyboard_type;
+        instance->settings->kbd_subtype = mod->client_info.keyboard_subtype;
     }
     else
     {

--- a/neutrinordp/xrdp-neutrinordp.c
+++ b/neutrinordp/xrdp-neutrinordp.c
@@ -1588,6 +1588,15 @@ lfreerdp_pre_connect(freerdp *instance)
                 PERF_DISABLE_THEMING;
                 // | PERF_DISABLE_CURSOR_SHADOW | PERF_DISABLE_CURSORSETTINGS;
     }
+
+    /* client time zone */
+    g_memcpy(instance->settings->client_time_zone, &mod->client_info.timezone_info,
+             sizeof(*instance->settings->client_time_zone));
+#ifdef XRDP_DEBUG
+    g_writeln("timezone info:");
+    g_hexdump(instance->settings->client_time_zone, sizeof(*instance->settings->client_time_zone));	
+#endif
+
     instance->settings->compression = 0;
     instance->settings->ignore_certificate = 1;
 


### PR DESCRIPTION
This changes adds support for getting the client time zone info in xrdp side.
Although its only needed now for NeutrinoRDP proxy scenario.

Another change for NeutrinoRDP is introduced in osirium/NeutrinoRDP#4 in order to make the proxy pass the correct client time zone.

- This is basically tested against an 2012 R2 machine through the proxy and seems to be working.
- I find an issue when you change the time zone on the remote server manually, then it sticks with the manually picked time zone when connecting back later (even when connecting directly). @KevP said it wasn't the case for him. consider testing this extensively.