### PR TITLE
lengthAndMask worked out incorrectly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ sesman/tools/xrdp-xcon
 sesman/xrdp-sesman
 stamp-h1
 xrdp/xrdp
+.vscode/*

--- a/libxrdp/libxrdp.c
+++ b/libxrdp/libxrdp.c
@@ -21,7 +21,12 @@
 #include "libxrdp.h"
 #include "xrdp_orders_rail.h"
 
+#ifdef XRDP_DEBUG
+#define LOG_LEVEL 99
+#else
 #define LOG_LEVEL 1
+#endif
+
 #define LLOG(_level, _args) \
     do { if (_level < LOG_LEVEL) { g_write _args ; } } while (0)
 #define LLOGLN(_level, _args) \
@@ -611,7 +616,10 @@ libxrdp_send_pointer_ex(struct xrdp_session *session, int cache_idx,
     init_stream(s, 8192);
 
     data_bytes = width * height * ((bpp + 7) / 8);
-    mask_bytes = width * height / 8;
+    /* 1 bpp, each scanline is padded up to a 2 byte boundary */
+    mask_bytes = ((7 + width) / 8);
+    mask_bytes = ((1 + mask_bytes) / 2) * 2;
+    mask_bytes = mask_bytes * height;
 
     if (session->client_info->use_fast_path & 1) /* fastpath output supported */
     {

--- a/libxrdp/xrdp_rdp.c
+++ b/libxrdp/xrdp_rdp.c
@@ -26,7 +26,12 @@
 #include <freerdp/constants.h>
 #endif
 
+#ifdef XRDP_DEBUG
+#define LOG_LEVEL 99
+#else
 #define LOG_LEVEL 1
+#endif
+
 #define LLOG(_level, _args) \
     do { if (_level < LOG_LEVEL) { g_write _args ; } } while (0)
 #define LLOGLN(_level, _args) \


### PR DESCRIPTION
* freerdp do checks against the formal spec, meaning they refused to
work when we calculated the lengthAndMask incorrectly
* lengthAndMask failed to pad each line up to a 2 byte boundary
* Also fixed debug logging in a few places where I needed it

https://osirium.atlassian.net/browse/OS-5192

See https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/71fad4fc-6ad4-4c7f-8103-a442bebaf7d2 for documentation on the padding. 
And https://github.com/FreeRDP/FreeRDP/blob/d96a61d8ca27056845f5cff24efb860bd5211f73/libfreerdp/core/update.c#L423 for where it used to failed in freeRDP.